### PR TITLE
docs: change codeowner name from italox to iaurg

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @jessescn @rafaeelaudibert @Italox @Dennissiq @jay-jlm
+*   @jessescn @rafaeelaudibert @iaurg @Dennissiq @jay-jlm


### PR DESCRIPTION

![Screen Shot 2020-01-14 at 9 51 23 pm](https://user-images.githubusercontent.com/9896958/72338191-120ff580-3718-11ea-878b-f0f548c0c0d7.png)
While building https://isgatsbytranslatedyet.org ([source code](https://github.com/nutboltu/is-gatsby-translated-yet)), I found this repository has an incorrect code owner name which never exists.

It seems @Italox doesn't exist and @iaurg  is the actual code owner.

This PR is to change the code owner name from  @Italox to @iaurg  

