### PR TITLE
New translation: remark-plugin-tutorial.md

### DIFF
--- a/docs/docs/remark-plugin-tutorial.md
+++ b/docs/docs/remark-plugin-tutorial.md
@@ -187,7 +187,7 @@ function visitor(node) {
 
 Aqui, ele encontrará todos os nós de texto e irá logar todos com um `console.log`. O segundo argumento pode ser substituído com qualquer tipagem descrita na [especificação Markdown AST (mdast)](https://github.com/syntax-tree/mdast#nodes) do Unist, incluindo tipagens como `paragraph`, `blockquote`, `link`, `image` ou, em nosso caso, `heading`.
 
-Com essa técnica em mente, nós podemos atravessar a AST similarmente com o seu plugin e adicionar uma funcionalidade adicional desta forma:
+Com essa técnica em mente, você pode atravessar a AST similarmente com o seu plugin e adicionar uma funcionalidade adicional desta forma:
 
 ```js:title=plugins/gatsby-remark-purple-headers/index.js
 const visit = require("unist-util-visit")

--- a/docs/docs/remark-plugin-tutorial.md
+++ b/docs/docs/remark-plugin-tutorial.md
@@ -168,7 +168,7 @@ Caso queira adicionar mais opções, você poderá mudar para a sintaxe de objet
 
 Quando estiver modificando nós, você irá querer navegar pela árvore e então implementar novas funcionalidades em nós específicos.
 
-Um node-module que pode lhe ajudar é o [unist-util-visit](https://github.com/syntax-tree/unist-util-visit), um navegador para nós `unist`. Para referência, Unist (Unified Syntax Tree) é um padrão adotado por árvores de sintaxe Markdown e interpretadores que inclui interpretadores já bem conhecidos no mundo do Gatsby como Remark e MDX.
+Um node module que pode lhe ajudar é o [unist-util-visit](https://github.com/syntax-tree/unist-util-visit), um navegador para nós `unist`. Para referência, Unist (Unified Syntax Tree) é um padrão adotado por árvores de sintaxe Markdown e interpretadores que inclui interpretadores já bem conhecidos no mundo do Gatsby como Remark e MDX.
 
 Como exemplificado no arquivo README do `unist-util-visit`, isso permite que uma interface visite nós particulares baseados em uma tipagem particular:
 

--- a/docs/docs/remark-plugin-tutorial.md
+++ b/docs/docs/remark-plugin-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial de Plugins para o Remark
+title: Criando sub-plugins do Remark
 ---
 
 [`gatsby-transformer-remark`](/packages/gatsby-transformer-remark) permite que desenvolvedores transformem arquivos Markdown em HTML que pode ser consumido através da API GraphQL do Gatsby. Blogs e outros sites baseados em exibição de conteúdo podem se beneficiar drasticamente das funcionalidades oferecidas por este plugin. Com ele, autores de conteúdo para o site não precisam se preocupar sobre como o site é escrito ou estruturado, concentrando-se ao invés disso em escrever conteúdo e posts engajadores!
@@ -115,7 +115,7 @@ Primeiro, crie um plugin local adicionando um diretório `plugins` ao seu site e
 
 ```js:title=plugins/gatsby-remark-purple-headers/index.js
 module.exports = ({ markdownAST }, pluginOptions) => {
-  // Manipulate AST
+  // Manipulação do AST
 
   return markdownAST
 }
@@ -159,7 +159,7 @@ Caso queira adicionar mais opções, você poderá mudar para a sintaxe de objet
 {
   resolve: `gatsby-remark-purple-headers`,
   options: {
-    // Options here
+    // Opções aqui
   }
 }
 ```
@@ -193,9 +193,9 @@ Com essa técnica em mente, nós podemos atravessar a AST similarmente com o seu
 const visit = require("unist-util-visit")
 
 module.exports = ({ markdownAST }, pluginOptions) => {
-  // highlight-next-line
+  // destaque-próxima-linha
   visit(markdownAST, "heading", node => {
-    // Do stuff with heading nodes
+    // Faz alguma coisa com os nós do cabeçalho
   })
 
   return markdownAST
@@ -241,10 +241,10 @@ module.exports = ({ markdownAST }, pluginOptions) => {
   visit(markdownAST, "heading", node => {
     let { depth } = node
 
-    // Skip if not an h1
+    // Ignora caso não seja um h1
     if (depth !== 1) return
 
-    // Grab the innerText of the heading node
+    // Pega o innerText do nó do cabeçalho
     let text = toString(node)
 
     const html = `

--- a/docs/docs/remark-plugin-tutorial.md
+++ b/docs/docs/remark-plugin-tutorial.md
@@ -109,7 +109,7 @@ Adicionalmente, o [AST Explorer](https://astexplorer.net/#/gist/d9029a2e8827265f
 
 ## Configurando um plugin
 
-Você irá criar um plugin que fará com que todos os cabeçalhos de alto-nível no Markdown tenham a cor roxa.
+Você irá criar um plugin que fará com que todos os cabeçalhos de alto nível no Markdown tenham a cor roxa.
 
 Primeiro, crie um plugin local adicionando um diretório `plugins` ao seu site e gerando um arquivo `package.json` para ele. Crie também um arquivo `index.js`. Nesse arquivo, exportaremos uma função que irá ser invocada pelo `gatsby-transformer-remark`:
 


### PR DESCRIPTION
#### Qual o objetivo dessa pull request?
<!-- Adicione um 'x' na opção que melhor se encaixe na pr >-->

* [x] Adição de uma nova tradução
* [ ] Correção em uma tradução existente

#### Qual arquivo foi traduzido/corrigido?
https://github.com/gatsbyjs/gatsby-pt-BR/blob/master/docs/docs/remark-plugin-tutorial.md

#### Algum comentário em relação a tradução?
Há certa ambiguidade na tradução do título 'Remark Plugin Tutorial' → 'Tutorial do Plugin Remark', já que o tutorial não refere-se ao plugin Remark em si, e sim à produção de sub-plugins para o mesmo. Traduzi para 'Tutorial de Plugins para o Remark'. Sintam-se livres para sugerir mudanças.

É citada com frequência a **Markdown Abstract Syntax Tree**. Optei por traduzir o termo para **Árvore de Sintaxe Abstrata do Markdown** e mencioná-lo nos parágrafos seguintes por sua sigla em inglês (AST), obedecendo o fluxo do documento original. Sintam-se livres para sugerir mudanças.

Em todas as ocorrências no documento o termo **node** foi traduzido para o termo **nó**, como sugerido por outro registro do glossário, 'DOM Node'.

Trechos de código foram mantidos em seus formatos originais.
